### PR TITLE
Prevent rapid clicking on ClientWord from performing text selection

### DIFF
--- a/app/components/ClientWord.tsx
+++ b/app/components/ClientWord.tsx
@@ -28,7 +28,7 @@ const ClientWord: React.FC<ClientWordProps> = ({
     }
   };
   return (
-    <span className={className} onClick={changeWord}>
+    <span className={className} onClick={changeWord} user-select="none">
       {currentWord}
     </span>
   );

--- a/app/components/ClientWord.tsx
+++ b/app/components/ClientWord.tsx
@@ -28,7 +28,7 @@ const ClientWord: React.FC<ClientWordProps> = ({
     }
   };
   return (
-    <span className={className} onClick={changeWord} user-select="none">
+    <span className={className} onClick={changeWord} style="user-select:none">
       {currentWord}
     </span>
   );


### PR DESCRIPTION
Prevent rapid clicking on ClientWord from performing text selection

Looks like user-select:none should fix

https://bobbyhadz.com/blog/disable-text-selection-on-double-click-in-javascript-or-css#disable-text-selection-on-double-click-using-css